### PR TITLE
Add basic session API

### DIFF
--- a/src/machinable/__init__.py
+++ b/src/machinable/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Union
 
 from .core import Component, Mixin
+from .core.session import get
 from .engine import Engine
 from .execution import Execution
 from .experiment import Experiment

--- a/src/machinable/__init__.py
+++ b/src/machinable/__init__.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, Union
 
 from .core import Component, Mixin
-from .core.session import get
 from .engine import Engine
 from .execution import Execution
 from .experiment import Experiment

--- a/src/machinable/core/component.py
+++ b/src/machinable/core/component.py
@@ -23,7 +23,7 @@ from ..utils.utils import apply_seed
 from .events import Events
 from .exceptions import ExecutionException
 from .mixin import Mixin, MixinInstance
-from .session import _SESSION
+from .session import session_set, session_unset
 
 
 def set_alias(obj, alias, value):
@@ -299,8 +299,7 @@ class Component(Mixin):
         actor_config=None,
         lifecycle=True,
     ):
-        # export to session
-        _SESSION["component"] = self
+        session_set("component", self)
 
         # Prepares and dispatches the components lifecycle and returns its result
         try:
@@ -383,8 +382,7 @@ class Component(Mixin):
                 message=f"The following exception occurred: {ex}\n{exception_to_str(ex)}",
             )
 
-        # unset from session
-        _SESSION["component"] = None
+        session_unset("component")
 
         return status
 

--- a/src/machinable/core/component.py
+++ b/src/machinable/core/component.py
@@ -23,6 +23,7 @@ from ..utils.utils import apply_seed
 from .events import Events
 from .exceptions import ExecutionException
 from .mixin import Mixin, MixinInstance
+from .session import _SESSION
 
 
 def set_alias(obj, alias, value):
@@ -298,6 +299,9 @@ class Component(Mixin):
         actor_config=None,
         lifecycle=True,
     ):
+        # export to session
+        _SESSION["component"] = self
+
         # Prepares and dispatches the components lifecycle and returns its result
         try:
             self._actor_config = actor_config
@@ -378,6 +382,9 @@ class Component(Mixin):
                 reason="exception",
                 message=f"The following exception occurred: {ex}\n{exception_to_str(ex)}",
             )
+
+        # unset from session
+        _SESSION["component"] = None
 
         return status
 

--- a/src/machinable/core/session.py
+++ b/src/machinable/core/session.py
@@ -1,0 +1,13 @@
+_SESSION = {}
+
+
+def get(key):
+    if key not in ["component", "store", "config", "flags", "log", "record"]:
+        raise ValueError(f"Invalid request: {key}")
+
+    component = _SESSION.get("component", None)
+
+    if key == "component":
+        return component
+
+    return getattr(component, key, None)

--- a/src/machinable/session/__init__.py
+++ b/src/machinable/session/__init__.py
@@ -1,0 +1,3 @@
+# public API of machinable.core.session
+
+from ..core.session import get

--- a/tests/core/core_session_test.py
+++ b/tests/core/core_session_test.py
@@ -1,10 +1,13 @@
 import machinable
+from machinable.session import get
 import pytest
 
 
 def test_session():
-    assert machinable.get("component") is None
+    assert machinable.session.get("component", default=None) is None
     assert machinable.execute("session", project="./test_project").failures == 0
-    assert machinable.get("component") is None
+    assert machinable.session.get("component", default=None) is None
     with pytest.raises(ValueError):
-        machinable.get("invalid")
+        machinable.session.get("invalid", default=None)
+    with pytest.raises(RuntimeError):
+        get("component")

--- a/tests/core/core_session_test.py
+++ b/tests/core/core_session_test.py
@@ -1,0 +1,10 @@
+import machinable
+import pytest
+
+
+def test_session():
+    assert machinable.get("component") is None
+    assert machinable.execute("session", project="./test_project").failures == 0
+    assert machinable.get("component") is None
+    with pytest.raises(ValueError):
+        machinable.get("invalid")

--- a/tests/test_project/machinable.yaml
+++ b/tests/test_project/machinable.yaml
@@ -153,6 +153,8 @@ components:nodes:
   - timings:
       test: 1
   - continuation:
+  - session:
+      value: test
 components:workers:
   - interactive:
       id: 1

--- a/tests/test_project/nodes/session.py
+++ b/tests/test_project/nodes/session.py
@@ -2,9 +2,9 @@ from machinable import Component
 
 
 def get_value():
-    import machinable
+    from machinable.session import get
 
-    return machinable.get("config").value
+    return get("config").value
 
 
 class SessionTesting(Component):

--- a/tests/test_project/nodes/session.py
+++ b/tests/test_project/nodes/session.py
@@ -1,0 +1,13 @@
+from machinable import Component
+
+
+def get_value():
+    import machinable
+
+    return machinable.get("config").value
+
+
+class SessionTesting(Component):
+    def on_create(self):
+        if self.config.value != get_value():
+            raise ValueError


### PR DESCRIPTION
This could be useful if a lot of code resides outside the currently used component. Instead of passing the component instance around, this allows to fetch session components anywhere via `machinable.get("component")`, `machinable.get("log")` etc.