### PR TITLE
Support for recursive config methods

### DIFF
--- a/src/machinable/core/component.py
+++ b/src/machinable/core/component.py
@@ -563,8 +563,8 @@ class Component(Mixin):
 
     def serialize(self):
         return {
-            "config": self.config.toDict(evaluate=True, with_hidden=False),
-            "flags": self.flags.toDict(evaluate=True),
+            "config": self.config.as_dict(evaluate=True, discard_hidden=True),
+            "flags": self.flags.as_dict(evaluate=True),
         }
 
     # life cycle

--- a/src/machinable/execution/execution.py
+++ b/src/machinable/execution/execution.py
@@ -572,13 +572,13 @@ class Execution(Jsonable):
                 "config.json",
                 {
                     "component": {
-                        "args": nd.config.toDict(evaluate=True),
-                        "flags": nd.flags.toDict(evaluate=True),
+                        "args": nd.config.as_dict(evaluate=True),
+                        "flags": nd.flags.as_dict(evaluate=True),
                     },
                     "components": [
                         {
-                            "args": comps[i].config.toDict(evaluate=True),
-                            "flags": comps[i].flags.toDict(evaluate=True),
+                            "args": comps[i].config.as_dict(evaluate=True),
+                            "flags": comps[i].flags.as_dict(evaluate=True),
                             "class": get_class_name(components[i]["class"]),
                         }
                         for i in range(len(comps))

--- a/src/machinable/project/export/standalone.py
+++ b/src/machinable/project/export/standalone.py
@@ -30,7 +30,7 @@ class ConfigMap(dict):
                 value = ConfigMap(value)
             self[key] = value
 
-    def toDict(self, *args, **kwargs):
+    def as_dict(self, *args, **kwargs):
         return self
 
     __delattr__ = dict.__delitem__

--- a/src/machinable/server/graphql/directives.py
+++ b/src/machinable/server/graphql/directives.py
@@ -9,7 +9,7 @@ from ...utils.dicts import serialize
 
 def to_json(obj):
     if isinstance(obj, ConfigMap):
-        obj = obj.toDict(evaluate=True)
+        obj = obj.as_dict(evaluate=True)
 
     return json.dumps(obj, default=serialize)
 

--- a/src/machinable/submission/collections/base.py
+++ b/src/machinable/submission/collections/base.py
@@ -1148,8 +1148,8 @@ class Collection:
         def _serialize(value):
             if hasattr(value, "serialize"):
                 return value.serialize()
-            elif hasattr(value, "toDict"):
-                return value.toDict()
+            elif hasattr(value, "as_dict"):
+                return value.as_dict()
             else:
                 return value
 

--- a/tests/config/config_mapping_test.py
+++ b/tests/config/config_mapping_test.py
@@ -15,7 +15,7 @@ def test_config_mapping_evaluate():
             "_mixin_": True,
             "~version": {"should be": "hidden"},
         }
-    ).toDict(with_hidden=False)
+    ).as_dict(discard_hidden=True)
 
     assert "_hidden" not in m
     assert m["_mixin_"]
@@ -76,7 +76,7 @@ class TestReadme(unittest.TestCase):
         m = ConfigMap(d)
         self.assertEqual(m.a, 1)
         self.assertEqual(m.b, 2)
-        d2 = m.toDict()
+        d2 = m.as_dict()
         self.assertIsInstance(d2, dict)
         self.assertNotIsInstance(d2, ConfigMap)
         self.assertEqual(len(d2), 3)
@@ -228,7 +228,7 @@ class TestRecursive(unittest.TestCase):
         outStr = str(m)
         self.assertIn("""a=5""", outStr)
         self.assertIn("""recursive=ConfigMap(...)""", outStr)
-        d = m.toDict()
+        d = m.as_dict()
         d_id = id(d)
         d["a"] = 5
         d["recursive"] = d
@@ -253,7 +253,7 @@ class Testkwarg(unittest.TestCase):
         def capture(**kwargs):
             return kwargs
 
-        self.assertEqual(a, capture(**b.toDict()))
+        self.assertEqual(a, capture(**b.as_dict()))
 
 
 class TestDeepCopy(unittest.TestCase):
@@ -292,7 +292,7 @@ class TestDeepCopy(unittest.TestCase):
 class TestConfigMapTupleToDict(unittest.TestCase):
     def test(self):
         m = ConfigMap({"a": 1, "b": (11, 22, ConfigMap({"c": 3}))})
-        d = m.toDict()
+        d = m.as_dict()
         self.assertEqual(d, {"a": 1, "b": (11, 22, {"c": 3})})
 
 

--- a/tests/test_project/configmethods.py
+++ b/tests/test_project/configmethods.py
@@ -13,3 +13,6 @@ class ConfMethods(Component):
 
     def config_arghello(self, arg):
         return arg
+
+    def config_recursive_call(self, arg):
+        return self.config.method + str(arg)

--- a/tests/test_project/machinable.yaml
+++ b/tests/test_project/machinable.yaml
@@ -134,6 +134,7 @@ components:
       nested:
         method: hello()
       global_method: global_conf(works=True)
+      resursive: recursive_call('test')
   - inherited_flatness:
       flat.can.be.useful: False
       inherited.flat: value


### PR DESCRIPTION
This extends ConfigMethods to allow for invocation of other ConfigMethods. Although this can lead to pathological cases like infinite recursions, it open up natural use cases similar to ordinary methods.