### PR TITLE
Make registration execution-specific

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -4,16 +4,4 @@ sidebar: auto
 
 # FAQ
 
-## Why do I have to change into the machinable project directory before running it?
-
-This has to do with how Python's import system handles relative imports with respect to the current working directory. As a result, the two following lines are not necessarily identical as the Python script may contain import statement that rely on the current working directory.
-
-```bash
-python example/main.py
-cd example && python main.py
-```
-
-To ensure that import dependencies are resolved correctly, machinable enforces execution from the project's root. 
-
-
-<br>
+Coming soon

--- a/src/machinable/engine/engine.py
+++ b/src/machinable/engine/engine.py
@@ -112,7 +112,8 @@ class Engine(Jsonable):
         if self.on_before_dispatch(execution) is False:
             return False
 
-        execution.storage.save_file("engine.json", self.serialize())
+        if not execution.storage.has_file("engine.json"):
+            execution.storage.save_file("engine.json", self.serialize())
 
         set_process_title(repr(execution))
         execution = self._dispatch(execution)

--- a/src/machinable/engine/slurm_engine.py
+++ b/src/machinable/engine/slurm_engine.py
@@ -189,7 +189,7 @@ class SlurmEngine(Engine):
                     "resources": canonical_resources,
                 }
                 execution.set_result(info, echo=False)
-                execution.storage.save_file(f"{component_id}/engine/info.json", info)
+                execution.storage.save_file(f"{component_id}/engine/slurm.json", info)
             except Exception as ex:
                 if isinstance(ex, sh.ErrorReturnCode):
                     message = ex.stderr.decode("utf-8")

--- a/src/machinable/registration/registration.py
+++ b/src/machinable/registration/registration.py
@@ -1,35 +1,17 @@
-import importlib
-
-from ..utils.formatting import exception_to_str, msg
-
-
 class Registration:
 
-    instance = None
+    _instance = None
 
     @classmethod
-    def get(cls):
-        if cls.instance is not None:
-            return cls.instance
+    def reset(cls, instance=None):
+        cls._instance = instance
 
-        try:
-            registration_module = importlib.import_module("_machinable")
-            registration_class = getattr(registration_module, "Project", False)
-            if registration_class:
-                cls.instance = registration_class()
-                return cls.instance
-        except ImportError as e:
-            if e.args and e.args[0] == "No module named '_machinable'":
-                pass
-            else:
-                msg(
-                    f"Could not import project registration. {e}\n{exception_to_str(e)}",
-                    level="error",
-                    color="fail",
-                )
+    @classmethod
+    def get(cls) -> "Registration":
+        if not isinstance(cls._instance, Registration):
+            cls._instance = cls()
 
-        cls.instance = Registration()
-        return cls.instance
+        return cls._instance
 
     def on_before_submit(self, execution):
         """Event triggered before submission of an execution

--- a/src/machinable/submission/component.py
+++ b/src/machinable/submission/component.py
@@ -292,15 +292,6 @@ class SubmissionComponent:
         return self.is_started() and not (self.is_active() or self.is_finished())
 
     @property
-    def engine(self):
-        """Returns engine information specific to this component"""
-        if "engine" not in self._cache:
-            self._cache["engine"] = config_map(
-                self.file("engine/info.json", default={})
-            )
-        return self._cache["engine"]
-
-    @property
     def view(self):
         """Returns the registered view"""
         return get_view("component", self)

--- a/tests/project/project_test.py
+++ b/tests/project/project_test.py
@@ -113,7 +113,11 @@ def test_parse_config():
     for k, v in config["components"].items():
         if k.find("@") != -1:
             continue
-        if v["module"] in ["test_project.component", "test_project.scope.section"]:
+        if v["module"] in [
+            "test_project.component",
+            "test_project.scope.section",
+            "test_project.uses_default_module",
+        ]:
             continue
         v["class"].load(instantiate=False)
 

--- a/tests/registration/registration_test.py
+++ b/tests/registration/registration_test.py
@@ -18,8 +18,6 @@ def test_registration_on_before_component_construction():
             if component["name"] == "dryrun":
                 os.environ["TEST3"] = flags.get("test", False)
 
-    Registration.instance = TestRegistration()
-
     @Execution
     class TestComponent(Component):
         def on_create(self):
@@ -36,6 +34,7 @@ def test_registration_on_before_component_construction():
             engine="native:None",
             project="./test_project",
         )
+        .set_registration(TestRegistration())
         .submit()
         .failures
         == 0

--- a/tests/submission/submission_views_test.py
+++ b/tests/submission/submission_views_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from machinable import Submission
-from machinable.submission import Views, SubmissionComponentView
+from machinable.submission import SubmissionComponentView, Views
 from machinable.submission.views.views import _used_attributes
 
 

--- a/tests/submission/test_submission.py
+++ b/tests/submission/test_submission.py
@@ -48,7 +48,6 @@ def test_submission_component():
     assert records.as_dataframe().size > 0
     assert len(comp.file("output.log")) > 0
     assert len(comp.file("log.txt")) > 0
-    assert len(comp.engine) == 0
 
     comp = Submission.find(get_path("subdirectory/TTTTTT"))
     assert comp.components.first().submission.submission_id == "TTTTTT"


### PR DESCRIPTION
Previously, Registration objects were loaded globally once an Execution object got instantiated. As a result, the registration process was unreliable and often counterintuitive. This make the registration execution specific meaning each Execution object can have its own Registration.