### PR TITLE
Rename element instance methods

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: machinable
-  text: research projects
+  text: research code
   tagline: A system to manage research code more effectively so you can move quickly while enabling reuse and collaboration.
   image:
     src: /logo/logo.png

--- a/src/machinable/collection.py
+++ b/src/machinable/collection.py
@@ -1399,7 +1399,7 @@ class ExperimentCollection(ElementCollection):
         execution = Execution.make(using, version=version)
 
         for experiment in self:
-            execution.add(experiment=experiment)
+            execution.use(experiment=experiment)
 
         execution.dispatch()
 

--- a/src/machinable/element.py
+++ b/src/machinable/element.py
@@ -93,7 +93,7 @@ class Connectable:
     @classmethod
     def get(cls) -> "Connectable":
         if getattr(cls, "_key", None) is not None:
-            return _CONNECTIONS.setdefault(cls._key, cls.use())
+            return _CONNECTIONS.setdefault(cls._key, cls.instance())
 
         return cls() if cls.__connection__ is None else cls.__connection__
 
@@ -365,7 +365,7 @@ class Element(Jsonable):
         )
 
     @classmethod
-    def use(
+    def instance(
         cls,
         module: Optional[str] = None,
         version: VersionType = None,

--- a/src/machinable/execution/execution.py
+++ b/src/machinable/execution/execution.py
@@ -32,7 +32,7 @@ class Execution(Element):
         )
 
     @classmethod
-    def use(
+    def instance(
         cls,
         module: Optional[str] = None,
         version: VersionType = None,
@@ -55,7 +55,7 @@ class Execution(Element):
     def from_model(cls, model: schema.Execution) -> "Execution":
         return super().from_model(model)
 
-    def add(
+    def use(
         self, experiment: Union[Experiment, List[Experiment]]
     ) -> "Execution":
         """Adds an experiment to the execution
@@ -65,7 +65,7 @@ class Execution(Element):
         """
         if isinstance(experiment, (list, tuple)):
             for _experiment in experiment:
-                self.add(_experiment)
+                self.use(_experiment)
             return self
 
         if not isinstance(experiment, Experiment):

--- a/src/machinable/experiment.py
+++ b/src/machinable/experiment.py
@@ -79,7 +79,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
         self._events: Events = Events()
 
     @classmethod
-    def use(
+    def instance(
         cls,
         module: Optional[str] = None,
         version: VersionType = None,
@@ -167,7 +167,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
         self._config = None
         self.__model__.config = None
 
-    def add(self, element: Union[Element, List[Element]]) -> "Experiment":
+    def use(self, element: Union[Element, List[Element]]) -> "Experiment":
         """Adds an element to the experiment
 
         # Arguments
@@ -177,7 +177,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
 
         if isinstance(element, (list, tuple)):
             for _element in element:
-                self.add(_element)
+                self.use(_element)
             return self
 
         if not isinstance(element, Element):
@@ -290,7 +290,9 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
 
         from machinable.execution.execution import Execution
 
-        Execution.use(using, version=version).add(experiment=self).dispatch()
+        Execution.instance(using, version=version).use(
+            experiment=self
+        ).dispatch()
 
         return self
 

--- a/src/machinable/project.py
+++ b/src/machinable/project.py
@@ -149,7 +149,7 @@ class Project(Connectable, Element):
         self._resolved_provider: Optional[Project] = None
 
     @classmethod
-    def use(
+    def instance(
         cls,
         directory: Optional[str] = None,
         version: VersionType = None,

--- a/src/machinable/storage/storage.py
+++ b/src/machinable/storage/storage.py
@@ -51,7 +51,7 @@ class Storage(Connectable, Element):
         )
 
     @classmethod
-    def use(
+    def instance(
         cls,
         module: Optional[str] = None,
         version: VersionType = None,

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -252,7 +252,7 @@ def test_connectable():
             _key = mode
 
             @classmethod
-            def use(cls):
+            def instance(cls):
                 return cls()
 
         dummy_1 = Dummy()
@@ -301,7 +301,7 @@ def test_element_relations(tmp_path):
         with Project("./tests/samples/project"):
 
             experiment = Experiment(group="test/group")
-            execution = Execution().add(experiment)
+            execution = Execution().use(experiment)
             execution.dispatch()
 
             experiment_clone = Experiment.from_storage(experiment.storage_id)
@@ -340,7 +340,7 @@ def test_element_relations(tmp_path):
             )
 
             experiment = CustomExperiment()
-            execution = CustomExecution().add(experiment)
+            execution = CustomExecution().use(experiment)
             execution.dispatch()
             experiment.__related__ = {}
             execution.__related__ = {}

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -5,9 +5,9 @@ from machinable import Execution, Experiment, Project, Storage
 
 
 def test_execution():
-    assert len(Execution().add([Experiment(), Experiment()]).experiments) == 2
+    assert len(Execution().use([Experiment(), Experiment()]).experiments) == 2
     with pytest.raises(ValueError):
-        Execution().add(None)
+        Execution().use(None)
     execution = Execution()
     assert (
         Execution.from_model(execution.__model__).timestamp
@@ -18,12 +18,12 @@ def test_execution():
     assert repr(Execution()) == "Execution"
 
     with Project("./tests/samples/project"):
-        execution = Execution().add(Experiment())
+        execution = Execution().use(Experiment())
         assert len(execution.experiments) == 1
         assert isinstance(execution.timestamp, float)
 
         experiment = Experiment()
-        execution = Execution.local().add(experiment)
+        execution = Execution.local().use(experiment)
         assert len(execution.experiments) == 1
         execution.dispatch()
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -96,7 +96,7 @@ def test_experiment(tmp_path):
         experiment.save_execution_data("test_deferred", "success")
         == "$deferred"
     )
-    execution = Execution().add(experiment)
+    execution = Execution().use(experiment)
     execution.dispatch()
     assert experiment.load_execution_data("test_deferred") == "success"
     experiment.save_execution_data("test", "data")
@@ -116,8 +116,8 @@ def test_experiment_relations(tmp_path):
     ):
         with Project("./tests/samples/project", name="test-project"):
 
-            experiment = Experiment.use("basic", group="test/group")
-            execution = Execution().add(experiment)
+            experiment = Experiment.instance("basic", group="test/group")
+            execution = Execution().use(experiment)
             execution.dispatch()
 
             assert experiment.project.name() == "test-project"
@@ -130,7 +130,7 @@ def test_experiment_relations(tmp_path):
 
             derived = Experiment(derived_from=experiment)
             assert derived.ancestor is experiment
-            derived_execution = Execution().add(derived).dispatch()
+            derived_execution = Execution().use(derived).dispatch()
 
             # invalidate cache and reconstruct
             experiment.__related__ = {}
@@ -143,12 +143,12 @@ def test_experiment_relations(tmp_path):
             assert experiment.derived[0].experiment_id == derived.experiment_id
 
             derived = Experiment(derived_from=experiment)
-            Execution().add(derived).dispatch()
+            Execution().use(derived).dispatch()
             assert len(experiment.derived) == 2
 
             assert experiment.derive().experiment_id != experiment.experiment_id
             derived = experiment.derive(version=experiment.config)
-            Execution().add(derived).dispatch()
+            Execution().use(derived).dispatch()
 
 
 class DataElement(Element):
@@ -162,9 +162,9 @@ class DataElement(Element):
 def test_experiment_elements():
     with Project("./tests/samples/project"):
         assert Experiment.singleton("dummy") is not None
-        experiment = Experiment.use("dummy")
+        experiment = Experiment.instance("dummy")
         dataset = DataElement({"dataset": "cifar"})
-        experiment.add(dataset)
+        experiment.use(dataset)
         assert experiment.elements[0].config.dataset == "cifar"
         experiment.execute()
         experiment.__related__ = {}

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -24,7 +24,7 @@ def test_storage_interface(tmpdir):
         experiment.save_file("test.json", "deferral")
         assert len(experiment._deferred_data) == 2
 
-        execution = Execution().add(experiment)
+        execution = Execution().use(experiment)
         repository.commit(experiment, execution)
 
         assert os.path.isfile(experiment.local_directory("data/test.txt"))


### PR DESCRIPTION
Use Element.instance() to make elements. This puts emphasis on the fact that multiple instances may exists, unlike in the case of singleton() creation.