### PR TITLE
Add on_before_dispatch event to experiment

### DIFF
--- a/src/machinable/execution/execution.py
+++ b/src/machinable/execution/execution.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import copy
 import os
-from multiprocessing.sharedctypes import Value
 
 from machinable import schema
 from machinable.collection import ExperimentCollection
@@ -130,11 +129,11 @@ class Execution(Element):
         return {}
 
     def dispatch(self) -> "Execution":
-        """Commits and dispatches the execution"""
-        self.commit()
-
+        """Dispatches the execution"""
         if self.on_before_dispatch() is False:
             return False
+
+        self.commit()
 
         results = self.on_dispatch()
 
@@ -150,6 +149,9 @@ class Execution(Element):
 
         Return False to prevent the dispatch
         """
+        # forward into experiment on_before_dispatch
+        for experiment in self.experiments:
+            experiment.on_before_dispatch()
 
     def on_after_dispatch(self, results: List[Any]) -> None:
         """Event triggered after the dispatch of an execution"""

--- a/src/machinable/experiment.py
+++ b/src/machinable/experiment.py
@@ -282,7 +282,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
         return self.__model__.version
 
     def execute(
-        self, using: Union[str, None] = None, version: VersionType = None
+        self, module: Union[str, None] = None, version: VersionType = None
     ) -> "Experiment":
         """Executes the experiment"""
         if self.is_finished():
@@ -290,7 +290,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
 
         from machinable.execution.execution import Execution
 
-        Execution.instance(using, version=version).use(
+        Execution.instance(module, version=version).use(
             experiment=self
         ).dispatch()
 
@@ -620,8 +620,11 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
 
     # life cycle
 
-    def on_init(self):
-        """Event when interface is initialised."""
+    def on_before_dispatch(self) -> Optional[bool]:
+        """Event triggered before the dispatch of the experiment
+
+        Return False to prevent the dispatch
+        """
 
     def on_dispatch(self):
         """Lifecycle event triggered at the very beginning of the component dispatch"""

--- a/src/machinable/storage/filesystem.py
+++ b/src/machinable/storage/filesystem.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 import json
 import os
 import sqlite3
-from multiprocessing.sharedctypes import Value
 
 from machinable import schema
 from machinable.errors import StorageError


### PR DESCRIPTION
This enables experiments to perform side-effect free runtime checks, such as inspecting if all required related elements are available.