### PR TITLE
Add project-wide override events

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 <div align="center">
 
-A modular system to manage research code effectively so you can move quickly while enabling reuse and collaboration.
-
 [![Build status](https://github.com/machinable-org/machinable/workflows/build/badge.svg)](https://github.com/machinable-org/machinable/actions?query=workflow%3Abuild)
 [![Dependencies Status](https://img.shields.io/badge/dependencies-up%20to%20date-brightgreen.svg)](https://github.com/machinable-org/machinable/pulls?utf8=%E2%9C%93&q=is%3Apr%20author%3Aapp%2Fdependabot)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/src/machinable/element.py
+++ b/src/machinable/element.py
@@ -156,16 +156,18 @@ class ConfigMethod:
         self.prefix = prefix
 
     def __call__(self, function, args) -> Any:
+        from machinable.project import Project
+
         definition = f"{function}({args})"
         method = f"{self.prefix}_{function}"
 
         if hasattr(self.element, method):
             obj = "self.element."
-        elif hasattr(self.element.parent, method):
-            obj = "self.element.parent."
+        elif hasattr(Project.get().provider(), method):
+            obj = "Project.get().provider()."
         else:
             raise AttributeError(
-                f"{self.prefix.title()} method {definition} specified but {type(self).__name__}.{method}() does not exist."
+                f"{self.prefix.title()} method {definition} specified but {type(self.element).__name__}.{method}() does not exist."
             )
 
         # Using eval is evil, but in this case there is probably not enough at stake
@@ -349,7 +351,7 @@ class Element(Jsonable):
         if base_class is None:
             base_class = getattr(machinable, cls._key, Element)
 
-        # prevent circlar instantiation
+        # prevent circular instantiation
         if module == "machinable" or module == base_class.__module__:
             return instantiate(
                 module, base_class, version, **constructor_kwargs

--- a/src/machinable/execution/execution.py
+++ b/src/machinable/execution/execution.py
@@ -27,7 +27,7 @@ class Execution(Element):
             module=self.__model__.module,
             config=self.__model__.config,
             version=self.__model__.version,
-            host=Project.get().get_host_info(),
+            host=Project.get().provider().get_host_info(),
         )
 
     @classmethod

--- a/src/machinable/experiment.py
+++ b/src/machinable/experiment.py
@@ -304,7 +304,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
             return False
 
         self.save_execution_data(
-            "host.json", data=Project.get().get_host_info()
+            "host.json", data=Project.get().provider().get_host_info()
         )
 
         return True

--- a/src/machinable/project.py
+++ b/src/machinable/project.py
@@ -177,6 +177,13 @@ class Project(Connectable, Element):
 
         return self._resolved_provider
 
+    @property
+    def module(self) -> Optional[str]:
+        if self.provider().__module__ != "machinable.project":
+            return self._provider.replace("/", ".")
+
+        return self.provider().__module__
+
     def add_to_path(self) -> None:
         if (
             os.path.exists(self.__model__.directory)
@@ -241,6 +248,9 @@ class Project(Connectable, Element):
         if base_class is None:
             base_class = Element
 
+        # allow overrides
+        module = self.provider().on_resolve_element(module)
+
         path = module
 
         # import project-relative
@@ -299,6 +309,9 @@ class Project(Connectable, Element):
             "argv": sys.argv,
             "machinable_version": get_machinable_version(),
         }
+
+    def on_resolve_element(self, module: str) -> str:
+        return module
 
     def on_resolve_vendor(
         self, name: str, source: str, target: str

--- a/src/machinable/project.py
+++ b/src/machinable/project.py
@@ -305,7 +305,6 @@ class Project(Connectable, Element):
             "machine": platform.machine(),
             "python_version": platform.python_version(),
             "user": getpass.getuser(),
-            "environ": os.environ.copy(),
             "argv": sys.argv,
             "machinable_version": get_machinable_version(),
         }

--- a/tests/samples/project/_machinable/project.py
+++ b/tests/samples/project/_machinable/project.py
@@ -13,3 +13,8 @@ class TestProject(Project):
             return "basic"
 
         return module
+
+    def get_host_info(self):
+        info = super().get_host_info()
+        info["dummy"] = "data"
+        return info

--- a/tests/samples/project/_machinable/project.py
+++ b/tests/samples/project/_machinable/project.py
@@ -5,12 +5,11 @@ class TestProject(Project):
     def config_global_conf(self, works=False):
         return works
 
-    def host_information(self) -> dict:
-        return {"custom_info": True, "host_info_return": "test"}
+    def version_global_ver(self, works=False):
+        return works
 
-    @staticmethod
-    def host_test_info_static():
-        return "static_test_info"
+    def on_resolve_element(self, module):
+        if module == "@test":
+            return "basic"
 
-    def host_test_info(self):
-        return "test_info"
+        return module

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -88,6 +88,9 @@ def test_element_config():
         def version_three(self):
             return {"alpha": 3}
 
+        def version_custom(self, alpha=2):
+            return {"alpha": alpha}
+
         def config_through_config_method(self, arg):
             return arg
 
@@ -104,6 +107,10 @@ def test_element_config():
     c = Dummy(("~three", "~one", "~two")).config
     assert c["alpha"] == 2
     assert c["beta"]["test"]
+
+    assert Dummy("~custom").config.alpha == 2
+    assert Dummy("~custom(3)").config.alpha == 3
+    assert Dummy("~custom(alpha=5)").config.alpha == 5
 
     # ingores None
     assert Dummy((None, {"alpha": -1}, None)).config.alpha == -1

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -29,4 +29,9 @@ def test_project_events():
         == Experiment.singleton("@test").hello()
     )
 
+    experiment = Experiment.instance("dummy")
+    experiment.execute()
+    info = experiment.load_execution_data("host.json")
+    assert info["dummy"] == "data"
+
     project.close()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,6 @@
 import os
 
-from machinable import Project
+from machinable import Experiment, Project
 
 
 def test_project():
@@ -11,4 +11,22 @@ def test_project():
     assert project.path().endswith("samples/project")
     project.connect()
     assert Project.get().name() == "test"
+    assert Project.get().module == "_machinable.project"
+    project.close()
+    assert Project.get().module == "machinable.project"
+
+
+def test_project_events():
+    project = Project("tests/samples/project").connect()
+    # global config
+    assert Experiment.instance("dummy", {"a": "global_conf(2)"}).config.a == 2
+    assert Experiment.instance("dummy", "~global_ver({'a': 3})").config.a == 3
+
+    # module redirection
+    assert Experiment.instance("@test").module == "basic"
+    assert (
+        Experiment.instance("@test").hello()
+        == Experiment.singleton("@test").hello()
+    )
+
     project.close()


### PR DESCRIPTION
Enables registration of project-wide config methods and versions as well as ways to override host information collection and element module resolution.