### PR TITLE
Adds configurable predicates

### DIFF
--- a/src/machinable/__init__.py
+++ b/src/machinable/__init__.py
@@ -29,6 +29,7 @@ from machinable.mixin import Mixin, mixin
 from machinable.project import Project
 from machinable.record import Record
 from machinable.schedule import Schedule
+from machinable.settings import get_settings
 from machinable.storage import Storage
 from machinable.types import Optional, VersionType
 
@@ -36,10 +37,10 @@ from machinable.types import Optional, VersionType
 def get(
     module: Optional[str] = None,
     version: VersionType = None,
-    mode: Optional[str] = "id",
+    predicate: Optional[str] = get_settings().default_predicate,
     **kwargs,
 ) -> Element:
-    return Element.get(module, version, mode, **kwargs)
+    return Element.get(module, version, predicate, **kwargs)
 
 
 def get_version() -> str:

--- a/src/machinable/execution.py
+++ b/src/machinable/execution.py
@@ -210,7 +210,7 @@ class Execution(Element):
 
     def on_dispatch(self):
         for experiment in self.experiments:
-            experiment.dispatch()
+            experiment()
 
     @property
     def timestamp(self) -> float:

--- a/src/machinable/project.py
+++ b/src/machinable/project.py
@@ -1,5 +1,5 @@
 import types
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import getpass
 import importlib
@@ -332,6 +332,10 @@ class Project(Element):
 
         Return False to prevent the default automatic resolution
         """
+
+    def global_predicates(self) -> Dict:
+        """Project-wide element predicates."""
+        return {}
 
     def __repr__(self) -> str:
         return f"Project({self.__model__.directory})"

--- a/src/machinable/schema.py
+++ b/src/machinable/schema.py
@@ -22,6 +22,7 @@ class Element(BaseModel):
     module: Optional[str] = None
     version: List[Union[str, Dict]] = []
     config: Optional[Dict] = None
+    predicate: Optional[Dict] = None
     lineage: Tuple[str, ...] = ()
 
 

--- a/src/machinable/settings.py
+++ b/src/machinable/settings.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 
 class Settings(BaseModel):
+    default_predicate: Optional[str] = "config"
     default_execution: Optional[List[Union[str, dict]]] = None
     default_storage: List[Union[str, dict]] = [
         "machinable.storage.filesystem",

--- a/src/machinable/storage/multiple.py
+++ b/src/machinable/storage/multiple.py
@@ -191,10 +191,10 @@ class Multiple(Storage):
     ) -> Optional[str]:
         return self._read("_find_experiment", experiment_id, timestamp)
 
-    def _find_experiment_by_version(
-        self, module: str, version: VersionType = None, mode: str = "exact"
+    def _find_experiment_by_predicate(
+        self, module: str, predicate: Dict
     ) -> List[str]:
-        return self._read("_find_experiment_by_version", module, version, mode)
+        return self._read("_find_experiment_by_predicate", module, predicate)
 
     def _find_related(
         self, storage_id: str, relation: str

--- a/src/machinable/storage/storage.py
+++ b/src/machinable/storage/storage.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from machinable import schema
 from machinable.element import Element, defaultversion, get_lineage, normversion
@@ -94,6 +94,7 @@ class Storage(Element):
                 continue
             # ensure that configuration has been parsed
             assert experiment.config is not None
+            assert experiment.predicate is not None
 
             group = experiment.group
             if group is None:
@@ -511,15 +512,13 @@ class Storage(Element):
     ) -> Optional[str]:
         raise NotImplementedError
 
-    def find_experiment_by_version(
-        self, module: str, version: VersionType = None, mode: str = "exact"
+    def find_experiment_by_predicate(
+        self, module: str, predicate: Optional[Dict] = None
     ) -> List[str]:
-        return self._find_experiment_by_version(
-            module, normversion(version), mode
-        )
+        return self._find_experiment_by_predicate(module, predicate)
 
-    def _find_experiment_by_version(
-        self, module: str, version: VersionType = None, mode: str = "exact"
+    def _find_experiment_by_predicate(
+        self, module: str, predicate: Dict
     ) -> List[str]:
         raise NotImplementedError
 

--- a/src/machinable/testing.py
+++ b/src/machinable/testing.py
@@ -12,9 +12,11 @@ def storage_tests(storage: Storage) -> None:
     pre_execution = schema.Execution()
     experiments = [
         schema.Experiment(
-            module="test.catch_me", version=["~if", {"you": "can"}]
+            module="test.catch_me", predicate={"if": {"you": "can"}}
         ),
-        schema.Experiment(module="test.catch_me", version=["~if"]),
+        schema.Experiment(
+            module="test.catch_me", predicate={"if": {"you": "cannot"}}
+        ),
         schema.Experiment(module="another"),
     ]
     project = schema.Project(directory=".", name="test")
@@ -91,18 +93,20 @@ def storage_tests(storage: Storage) -> None:
         == experiments[0]._storage_id
     )
     assert storage.find_experiment("not-existing") is None
-    # search by version
-    assert len(storage.find_experiment_by_version("non-existing")) == 0
-    assert len(storage.find_experiment_by_version(module="test.catch_me")) == 2
+    # search by predicate
+    assert len(storage.find_experiment_by_predicate("non-existing")) == 0
     assert (
-        storage.find_experiment_by_version(
-            module="test.catch_me", version=["~if", {"you": "can"}]
+        len(storage.find_experiment_by_predicate(module="test.catch_me")) == 2
+    )
+    assert (
+        storage.find_experiment_by_predicate(
+            module="test.catch_me", predicate={"if": {"you": "can"}}
         )[0]
         == experiments[0]._storage_id
     )
     assert (
-        storage.find_experiment_by_version(
-            module="test.catch_me", version=[{"you": "can"}]
+        storage.find_experiment_by_predicate(
+            module="test.catch_me", predicate={"if": "can"}
         )
         == []
     )

--- a/tests/samples/project/_machinable/project.py
+++ b/tests/samples/project/_machinable/project.py
@@ -18,3 +18,6 @@ class TestProject(Project):
         info = super().get_host_info()
         info["dummy"] = "data"
         return info
+
+    def global_predicates(self):
+        return {"more": 1}

--- a/tests/samples/project/dummy.py
+++ b/tests/samples/project/dummy.py
@@ -4,6 +4,7 @@ from machinable import Experiment
 class Dummy(Experiment):
     class Config:
         a: int = 1
+        ignore_me_: int = -1
 
     def name(self):
         return "dummy"

--- a/tests/samples/project/predicate.py
+++ b/tests/samples/project/predicate.py
@@ -1,0 +1,14 @@
+from machinable import Experiment
+
+
+class PredicateExperiment(Experiment):
+    class Config:
+        a: int = 1
+        ignore_: int = 2
+
+    def on_predicate(self):
+        p = super().on_predicate()
+
+        p["test"] = "a"
+
+        return p

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -13,10 +13,15 @@ def test_collect():
     assert isinstance(collect([1, 2]), Collection)
 
 
+class DummyExperiment(Experiment):
+    class Config:
+        m: int = -1
+
+
 def test_experiment_collection(tmp_storage):
     with Project("./tests/samples/project"):
         collection = Experiment.collect(
-            [Experiment({"m": i % 2}) for i in range(5)]
+            [DummyExperiment({"m": i % 2}) for i in range(5)]
         )
         for i, e in enumerate(collection):
             e.save_data("i", i)
@@ -31,23 +36,13 @@ def test_experiment_collection(tmp_storage):
         assert len(collection.incomplete()) == 0
         assert len(collection.started().active()) == 0
 
-        assert len(collection.filter_by_version("non-existent")) == 0
-        assert len(collection.filter_by_version("machinable.experiment")) == 0
-        assert (
-            len(collection.filter_by_version("machinable.experiment", {"m": 0}))
-            == 3
-        )
-        assert (
-            len(collection.filter_by_version("machinable.experiment", {"m": 1}))
-            == 2
-        )
+        assert len(collection.filter_by_predicate("non-existent")) == 0
+        m = "tests.test_collection"
+        assert len(collection.filter_by_predicate(m)) == 0
+        assert len(collection.filter_by_predicate(m, {"m": 0})) == 3
+        assert len(collection.filter_by_predicate(m, {"m": 1})) == 2
 
-        assert (
-            collection.singleton("machinable.experiment", {"m": 1}).load_data(
-                "i"
-            )
-            == "1"
-        )
+        assert collection.singleton(m, {"m": 1}).load_data("i") == "1"
 
 
 class CollectionTestCase(TestCase):

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -419,8 +419,10 @@ def test_element_search(tmp_storage):
         exp2 = Experiment.make("dummy", {"a": 2})
         exp2.launch()
         assert Experiment.find(exp1.experiment_id).timestamp == exp1.timestamp
-        assert Experiment.find_by_version("non-existing").empty()
-        assert Experiment.find_by_version("dummy").count() == 2
+        assert Experiment.find_by_predicate("non-existing").empty()
+        assert (
+            Experiment.find_by_predicate("dummy", predicate=None).count() == 2
+        )
         # singleton
         assert (
             Experiment.singleton("dummy", {"a": 2}).timestamp == exp2.timestamp


### PR DESCRIPTION
This exposes the predicates used to determine equality during singleton lookup. The dynamic nature makes it vastly more powerful than the previously hardcoded lookup as users can choose to define their own criteria, for example code version or relationships etc.