### PR TITLE
Support in-session element instances

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -216,6 +216,21 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "dill"
+version = "0.3.6"
+description = "serialize all of python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
+    {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
+]
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
+
+[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -835,4 +850,4 @@ all = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "51c48d2b60313d420fb263a5eac514fa6425f1e3c796f6e406cdbf404ee1166b"
+content-hash = "7c2bb64d6f9dba044bf4973ec908016f29632bf90aca07ee5a2e5645dceb49b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ arrow = "^1.2"
 importlib-metadata = {version = "^6.0", python = "<3.8"}
 commandlib = "^0.3.5"
 omegaconf = "^2.3.0"
+dill = "^0.3.6"
 
 
 [tool.poetry.dev-dependencies]

--- a/src/machinable/__init__.py
+++ b/src/machinable/__init__.py
@@ -31,11 +31,11 @@ from machinable.record import Record
 from machinable.schedule import Schedule
 from machinable.settings import get_settings
 from machinable.storage import Storage
-from machinable.types import Optional, VersionType
+from machinable.types import Optional, Union, VersionType
 
 
 def get(
-    module: Optional[str] = None,
+    module: Union[str, Element, None] = None,
     version: VersionType = None,
     predicate: Optional[str] = get_settings().default_predicate,
     **kwargs,

--- a/src/machinable/execution.py
+++ b/src/machinable/execution.py
@@ -8,6 +8,7 @@ from machinable.element import (
     Element,
     defaultversion,
     extract,
+    get_dump,
     get_lineage,
     has_many,
     has_one,
@@ -43,6 +44,7 @@ class Execution(Element):
             host_info=Project.get().provider().get_host_info(),
             lineage=get_lineage(self),
         )
+        self.__model__._dump = get_dump(self)
         if schedule is not None:
             if not isinstance(schedule, Schedule):
                 schedule = Schedule.make(*extract(schedule))

--- a/src/machinable/experiment.py
+++ b/src/machinable/experiment.py
@@ -17,6 +17,7 @@ from machinable.element import (
     Element,
     belongs_to,
     defaultversion,
+    get_dump,
     get_lineage,
     has_many,
     normversion,
@@ -60,6 +61,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
             seed=seed,
             lineage=get_lineage(self),
         )
+        self.__model__._dump = get_dump(self)
         if derived_from is not None:
             self.__model__.derived_from_id = derived_from.experiment_id
             self.__model__.derived_from_timestamp = derived_from.timestamp
@@ -176,7 +178,7 @@ class Experiment(Element):  # pylint: disable=too-many-public-methods
 
     def derive(
         self,
-        module: Optional[str] = None,
+        module: Union[str, Element, None] = None,
         version: VersionType = None,
         predicate: Optional[str] = get_settings().default_predicate,
         **kwargs,

--- a/src/machinable/group.py
+++ b/src/machinable/group.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from machinable import schema
 from machinable.collection import ExperimentCollection
-from machinable.element import Element, get_lineage, has_many
+from machinable.element import Element, get_dump, get_lineage, has_many
 from machinable.types import VersionType
 
 
@@ -40,6 +40,7 @@ class Group(Element):
             path=path,
             lineage=get_lineage(self),
         )
+        self.__model__._dump = get_dump(self)
 
     @property
     def pattern(self) -> str:

--- a/src/machinable/mixin.py
+++ b/src/machinable/mixin.py
@@ -72,9 +72,11 @@ def mixin(f: Callable) -> Any:
         if name not in self.__mixins__:
             mixin_class = f(self)
             if isinstance(mixin_class, str):
-                from machinable.project import Project
+                from machinable.project import Project, import_element
 
-                mixin_class = Project.get()._element(mixin_class, Mixin)
+                mixin_class = import_element(
+                    Project.get().path(), mixin_class, Mixin
+                )
 
             self.__mixins__[name] = bind(self, mixin_class, name)
 

--- a/src/machinable/record.py
+++ b/src/machinable/record.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional, Union
 import copy
 
 from machinable import schema
-from machinable.element import Element, belongs_to, get_lineage
+from machinable.element import Element, belongs_to, get_dump, get_lineage
 from machinable.errors import StorageError
 from machinable.experiment import Experiment
 from machinable.types import JsonableType, VersionType
@@ -28,6 +28,7 @@ class Record(Element):
             scope=scope,
             lineage=get_lineage(self),
         )
+        self.__model__._dump = get_dump(self)
         self.__related__["experiment"] = experiment
 
     @belongs_to

--- a/src/machinable/schedule.py
+++ b/src/machinable/schedule.py
@@ -1,6 +1,6 @@
 from machinable import schema
 from machinable.collection import ExecutionCollection
-from machinable.element import Element, get_lineage
+from machinable.element import Element, get_dump, get_lineage
 from machinable.types import VersionType
 
 
@@ -17,3 +17,4 @@ class Schedule(Element):
             version=self.__model__.version,
             lineage=get_lineage(self),
         )
+        self.__model__._dump = get_dump(self)

--- a/src/machinable/schema.py
+++ b/src/machinable/schema.py
@@ -19,6 +19,7 @@ class Element(BaseModel):
     # morphMany relation to storage
     _storage_id: Optional[str] = PrivateAttr(default=None)
     _storage_instance: Optional["Storage"] = PrivateAttr(default=None)
+    _dump: Optional[bytes] = PrivateAttr(default=None)
     module: Optional[str] = None
     version: List[Union[str, Dict]] = []
     config: Optional[Dict] = None

--- a/src/machinable/storage/filesystem.py
+++ b/src/machinable/storage/filesystem.py
@@ -144,6 +144,11 @@ class Filesystem(Storage):
                 execution.dict(),
                 makedirs=True,
             )
+            if execution._dump is not None:
+                save_file(
+                    os.path.join(execution_directory, "execution.p"),
+                    execution._dump,
+                )
 
         cur = self._db.cursor()
         cur.execute(
@@ -268,6 +273,10 @@ class Filesystem(Storage):
             experiment.dict(),
             makedirs=True,
         )
+        if experiment._dump is not None:
+            save_file(
+                os.path.join(storage_id, "experiment.p"), experiment._dump
+            )
 
         save_file(
             os.path.join(storage_id, "project.json"),
@@ -494,14 +503,22 @@ class Filesystem(Storage):
         return [row[0] for row in query.fetchall()]
 
     def _retrieve_execution(self, storage_id: str) -> schema.Execution:
-        return schema.Execution(
+        execution = schema.Execution(
             **load_file(os.path.join(storage_id, "execution.json")),
         )
+        execution._dump = load_file(
+            os.path.join(storage_id, "execution.p"), None
+        )
+        return execution
 
     def _retrieve_experiment(self, storage_id: str) -> schema.Experiment:
-        return schema.Experiment(
+        experiment = schema.Experiment(
             **load_file(os.path.join(storage_id, "experiment.json")),
         )
+        experiment._dump = load_file(
+            os.path.join(storage_id, "experiment.p"), None
+        )
+        return experiment
 
     def _retrieve_group(self, storage_id: str) -> schema.Group:
         self.migrate()

--- a/src/machinable/storage/storage.py
+++ b/src/machinable/storage/storage.py
@@ -1,7 +1,13 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from machinable import schema
-from machinable.element import Element, defaultversion, get_lineage, normversion
+from machinable.element import (
+    Element,
+    defaultversion,
+    get_dump,
+    get_lineage,
+    normversion,
+)
 from machinable.group import Group
 from machinable.project import Project
 from machinable.settings import get_settings
@@ -51,6 +57,7 @@ class Storage(Element):
             default_group=default_group,
             lineage=get_lineage(self),
         )
+        self.__model__._dump = get_dump(self)
 
     @classmethod
     def instance(

--- a/src/machinable/utils.py
+++ b/src/machinable/utils.py
@@ -6,7 +6,6 @@ import importlib
 import inspect
 import json
 import os
-import pickle
 import random
 import re
 import string
@@ -16,6 +15,7 @@ from pathlib import Path
 
 import arrow
 import commandlib
+import dill as pickle
 import jsonlines
 import omegaconf
 from baseconv import base62

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -501,4 +501,4 @@ def test_element_interactive_session(tmp_storage):
     # serialization
     exec(t.dispatch_code(inline=False) + "\nassert experiment__.is_valid()")
     # retrieval
-    assert t.timestamp == get(T).timestamp
+    assert t.experiment_id == get(T).experiment_id

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -207,7 +207,7 @@ def test_element_config():
         )
 
 
-def test_component_config_schema():
+def test_element_config_schema():
     class Basic(Element):
         class Config:
             hello: str = ""
@@ -485,3 +485,20 @@ def test_element_interface(tmp_storage):
     uncommitted = Element()
     uncommitted.save_data("test", "deferred")
     assert uncommitted.load_data("test") == "deferred"
+
+
+def test_element_interactive_session(tmp_storage):
+    class T(Experiment):
+        def is_valid(self):
+            return True
+
+    t = get(T)
+    assert t.module == "__session__T"
+    assert t.__model__._dump is not None
+
+    # default launch
+    t.launch()
+    # serialization
+    exec(t.dispatch_code(inline=False) + "\nassert experiment__.is_valid()")
+    # retrieval
+    assert t.timestamp == get(T).timestamp


### PR DESCRIPTION
This removes a prior limitation that required users to define elements in module files to enable re-import. Now, users are free to use element instances that are defined in the current session; machinable will fall back on pickle to serialize and re-import these elements if needed.